### PR TITLE
Add pattern match methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add pattern match methods (`deconstruct_keys`) for `Gemtext::Node` nad `Gemtext::Link`.
+
 ## v1.0.0
 
 * Parse a Gemtext::Document from a Ruby IO

--- a/lib/gemtext/link.rb
+++ b/lib/gemtext/link.rb
@@ -16,5 +16,9 @@ module Gemtext
     def ==(other)
       other.class == self.class && other.target == @target && other.description == @description
     end
+
+    def deconstruct_keys(*_keys)
+      { **super, target:, description: }
+    end
   end
 end

--- a/lib/gemtext/node.rb
+++ b/lib/gemtext/node.rb
@@ -17,5 +17,9 @@ module Gemtext
     def ==(other)
       other.class == self.class && other.content == @content
     end
+
+    def deconstruct_keys(*_keys)
+      { content: }
+    end
   end
 end


### PR DESCRIPTION
Hello,

This adds pattern match methods (`deconstruct_keys`) for `Node` and `Link`.
Example usage in Ruby 3.1 or later:

```ruby
case node # is a Node
in Gemtext::Heading[content:] # subclass of Node
  print "\\section{#{content}}\n"
in Gemtext::Link[target:, description:]
  print "#{description} (\\url{#{target}})\n"
# ...
end
```

Thank you.