### PR TITLE
Wrap regexp argument in parentheses

### DIFF
--- a/lib/gemtext/parser.rb
+++ b/lib/gemtext/parser.rb
@@ -49,7 +49,7 @@ module Gemtext
             Whitespace[nil]
           when /^=>/
             without_arrow = stripped.delete_prefix('=>').strip
-            pieces = without_arrow.split /\s+/
+            pieces = without_arrow.split(/\s+/)
             url = pieces.first
             description = pieces.drop(1).join ' ' # TODO: Preserve whitespace in description
 


### PR DESCRIPTION
This fixes regexp arguments of `Gemtext::Parser#parse` in `lib/gemtext/parser.rb`,
and suppress the following:

> warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator